### PR TITLE
Fix move logic

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,12 +1,13 @@
 class PiecesController < ApplicationController
   before_action :find_piece, :only => [:show, :update]
+
   def show
   end
 
   def update
     @game = @piece.game
     @pieces = @piece.game.pieces
-    if @piece.move_to!(params[:x_pos], params[:y_pos])
+    if @piece.valid_move?(params[:x_pos].to_i, params[:y_pos].to_i) && @piece.move_to!(params[:x_pos], params[:y_pos])
       redirect_to game_path(@game.id)
     else
       flash.now[:alert] = "Piece cannot move there!"

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -28,9 +28,11 @@ class Pawn < Piece
 
     # Can move 2 or 1 spaces forward on first move.
     if !self.has_moved
+      self.update_attributes(has_moved: true)
       return true if (y_diff == 2 || y_diff == 1) && x_diff == 0
     # Can move only 1 space forward after first move
     else
+      self.update_attributes(has_moved: true)
       return true if y_diff == 1 && x_diff == 0
     end
 

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -17,14 +17,26 @@ class Pawn < Piece
       y_diff = y_dest - self.y_pos
     else
       y_diff = (y_dest - self.y_pos).abs
+      backwards_check = y_dest - self.y_pos
     end
 
     # Can't move backwards
-    return false if y_diff < 1
+    return false if color == "white" && y_diff < 1
+    return false if color == "black" && backwards_check > 0
+
     # Can't move more than 2 spaces forward and 1 space left or right
     return false if y_diff > 2 || x_diff > 1
 
-    dest_piece ||= self.game.pieces.find_by(x_pos: x_dest, y_pos: y_dest, active: true)
+    if x_diff == y_diff
+      dest_piece = piece_at_location(x_dest, y_dest)
+
+      # Can move one space diagonally as long as a piece of the opposite color is on the destination spot
+      if dest_piece
+        return false if x_diff != y_diff
+        return false if dest_piece.color == self.color
+        return true if (((y_diff == x_diff) && x_diff == 1) && dest_piece.color != self.color)
+      end
+    end
 
     # Can move 2 or 1 spaces forward on first move.
     if !self.has_moved
@@ -34,11 +46,6 @@ class Pawn < Piece
     else
       self.update_attributes(has_moved: true)
       return true if y_diff == 1 && x_diff == 0
-    end
-
-    # Can move one space diagonally as long as a piece of the opposite color is on the destination spot
-    if dest_piece
-      return true if (((y_diff == x_diff) && x_diff == 1) && dest_piece.color != self.color)
     end
 
     # All other moves are invalid

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -13,7 +13,11 @@ class Pawn < Piece
 
   def legal_move?(x_dest, y_dest)
     x_diff = (x_dest - self.x_pos).abs
-    y_diff = y_dest - self.y_pos
+    if color == "white"
+      y_diff = y_dest - self.y_pos
+    else
+      y_diff = (y_dest - self.y_pos).abs
+    end
 
     # Can't move backwards
     return false if y_diff < 1

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -27,25 +27,25 @@ class Pawn < Piece
     # Can't move more than 2 spaces forward and 1 space left or right
     return false if y_diff > 2 || x_diff > 1
 
-    if x_diff == y_diff
-      dest_piece = piece_at_location(x_dest, y_dest)
+    dest_piece = piece_at_location(x_dest, y_dest)
 
+    if x_diff == y_diff
       # Can move one space diagonally as long as a piece of the opposite color is on the destination spot
       if dest_piece
-        return false if x_diff != y_diff
         return false if dest_piece.color == self.color
         return true if (((y_diff == x_diff) && x_diff == 1) && dest_piece.color != self.color)
       end
-    end
-
-    # Can move 2 or 1 spaces forward on first move.
-    if !self.has_moved
-      self.update_attributes(has_moved: true)
-      return true if (y_diff == 2 || y_diff == 1) && x_diff == 0
-    # Can move only 1 space forward after first move
     else
-      self.update_attributes(has_moved: true)
-      return true if y_diff == 1 && x_diff == 0
+      # Can move 2 or 1 spaces forward on first move.
+      if !self.has_moved
+        self.update_attributes(has_moved: true)
+        return true if (y_diff == 2 || y_diff == 1) && x_diff == 0 && dest_piece == nil
+      # Can move only 1 space forward after first move
+      else
+        self.update_attributes(has_moved: true)
+        return true if y_diff == 1 && x_diff == 0 && dest_piece == nil
+      end
+      return false
     end
 
     # All other moves are invalid

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -108,7 +108,7 @@ class Piece < ActiveRecord::Base
   private
 
   def piece_at_location(x, y)
-    return self.class.find_by(
+    return self.game.pieces.find_by(
       game_id: self.game_id,
       x_pos: x,
       y_pos: y,

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -5,10 +5,10 @@ class Rook < Piece
   end
 
   def legal_move?(x_destination, y_destination)
-    if (x_pos - x_destination).abs == (y_pos - y_destination).abs
-      return false
+    if (x_pos == x_destination && y_pos != y_destination) || (y_pos == y_destination && x_pos != x_destination)
+      return true
     end
-    true
+    return false
   end
   # The rook may move as far as it wants, but only forward, backward, and to the sides.
 

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe PiecesController, type: :controller do
   describe "piece#update action" do
     it "should successfully update the position of the piece" do
       game = FactoryGirl.create(:game)
+      game.pieces.delete_all
       piece = FactoryGirl.create(:piece, game_id: game.id, x_pos: 0, y_pos: 0)
       put :update, id: piece.id, :x_pos => 0, :y_pos => 5
       piece.reload


### PR DESCRIPTION
Fixed some issues found in some move logic methods. Biggest problem was in Pawn. The original logic did not allow black pawns to move. I also forgot to set the has_moved flag to true when the pawn moved.

Cleaned up Rook's legal_move.

Valid_move is now called automatically when a piece attempts to move.